### PR TITLE
Update afl-llvm-pass.so.cc

### DIFF
--- a/llvm_mode/afl-llvm-pass.so.cc
+++ b/llvm_mode/afl-llvm-pass.so.cc
@@ -44,6 +44,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 


### PR DESCRIPTION
Need to include raw_ostream.h when I use LLVM_CONFIG=llvm-config-10 and clang 10.0.0-4ubuntu1.